### PR TITLE
fix: correct nushell syntax in dgx.nu nvidia-smi command

### DIFF
--- a/scripts/nu/modules/dgx.nu
+++ b/scripts/nu/modules/dgx.nu
@@ -554,8 +554,7 @@ export def dgx-get-cuda-version [] {
     let driver_version = if (command-exists "nvidia-smi") {
         (do {
             try {
-                ^nvidia-smi --query-gpu=driver_version
-                --format=csv,noheader
+                ^nvidia-smi --query-gpu=driver_version --format=csv,noheader
                 | lines
                 | first
                 | str trim


### PR DESCRIPTION
## Summary
- Fix multi-line external command syntax error in `dgx-get-cuda-version` function
- Consolidated nvidia-smi command and flags onto single line

## Problem
The nvidia-smi command was split across multiple lines:
```nu
^nvidia-smi --query-gpu=driver_version
--format=csv,noheader
```

This caused nushell parser to treat the second line as a separate command, resulting in CI failure.

## Solution
```nu
^nvidia-smi --query-gpu=driver_version --format=csv,noheader
```

## Impact
- Fixes nushell syntax check in CI
- Allows all PRs to pass the nushell check after rebasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)